### PR TITLE
fix: create headscale config dir

### DIFF
--- a/charts/headscale/Chart.yaml
+++ b/charts/headscale/Chart.yaml
@@ -4,7 +4,7 @@ description: An open source, self-hosted implementation of the Tailscale control
 home: https://charts.gabe565.com/charts/headscale/
 icon: https://raw.githubusercontent.com/juanfont/headscale/56a7b1e34952c3e0306a134b2be9b4277f5d8d6e/docs/logo/headscale3-dots.svg
 type: application
-version: 0.12.6
+version: 0.12.7
 # renovate datasource=docker depName=ghcr.io/juanfont/headscale
 appVersion: 0.22.3
 kubeVersion: ">=1.22.0-0"
@@ -25,8 +25,8 @@ sources:
   - https://github.com/juanfont/headscale
 annotations:
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update postgresql helm release to v12.12.10
+    - kind: fixed
+      description: Create Headscale config dir
   artifacthub.io/links: |-
     - name: App Source
       url: https://github.com/juanfont/headscale

--- a/charts/headscale/README.md
+++ b/charts/headscale/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://raw.githubusercontent.com/juanfont/headscale/56a7b1e34952c3e0306a134b2be9b4277f5d8d6e/docs/logo/headscale3-dots.svg" align="right" width="92" alt="headscale logo">
 
-![Version: 0.12.6](https://img.shields.io/badge/Version-0.12.6-informational?style=flat)
+![Version: 0.12.7](https://img.shields.io/badge/Version-0.12.7-informational?style=flat)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat)
 ![AppVersion: 0.22.3](https://img.shields.io/badge/AppVersion-0.22.3-informational?style=flat)
 
@@ -11,7 +11,7 @@ An open source, self-hosted implementation of the Tailscale control server.
 **Homepage:** <https://charts.gabe565.com/charts/headscale/>
 
 **This chart is not maintained by the upstream project and any issues with the chart should be raised
-[here](https://github.com/gabe565/charts/issues/new?assignees=gabe565&labels=bug&template=bug_report.yaml&name=headscale&version=0.12.6)**
+[here](https://github.com/gabe565/charts/issues/new?assignees=gabe565&labels=bug&template=bug_report.yaml&name=headscale&version=0.12.7)**
 
 ## Source Code
 

--- a/charts/headscale/templates/common.yaml
+++ b/charts/headscale/templates/common.yaml
@@ -21,6 +21,7 @@ initContainers:
           echo 'Config already exists' >&2
         else
           echo 'Writing empty config' >&2
+          mkdir -p $CONFIG_DIR
           cat <<- 'EOF' >"$CONFIG_DIR/config.yaml"
             # It's suggested to use environment variables to configure Headscale.
             # For config reference, see https://github.com/juanfont/headscale/blob/main/config-example.yaml

--- a/charts/headscale/templates/common.yaml
+++ b/charts/headscale/templates/common.yaml
@@ -21,7 +21,7 @@ initContainers:
           echo 'Config already exists' >&2
         else
           echo 'Writing empty config' >&2
-          mkdir -p $CONFIG_DIR
+          mkdir -p "$CONFIG_DIR"
           cat <<- 'EOF' >"$CONFIG_DIR/config.yaml"
             # It's suggested to use environment variables to configure Headscale.
             # For config reference, see https://github.com/juanfont/headscale/blob/main/config-example.yaml


### PR DESCRIPTION
Prevents the following init container error:

```
Writing empty config
sh: can't create /etc/headscale/config.yaml: nonexistent directory
```