### PR TITLE
Adding comments for using a default secret for redis auth

### DIFF
--- a/charts/paperless-ngx/values.yaml
+++ b/charts/paperless-ngx/values.yaml
@@ -122,6 +122,10 @@ redis:
   enabled: true
   auth:
     enabled: true
+    # Use an existing secret for redis auth. Do this if you're using Argo to manage your instance or otherwise converting helm to kustomize under the hood
+    #     Make sure to use the exact names below.
+    # existingSecret: tahiti-redis
+    # existingSecretPasswordKey: redis-password
   master:
     persistence:
       enabled: false

--- a/charts/paperless-ngx/values.yaml
+++ b/charts/paperless-ngx/values.yaml
@@ -122,7 +122,7 @@ redis:
   enabled: true
   auth:
     enabled: true
-    # Use an existing secret for redis auth. Do this if you're using Argo to manage your instance or otherwise converting helm to kustomize under the hood
+    # Use an existing secret for redis auth. Do this if you're using Argo to manage your instance or otherwise using helm template under the hood
     #     The secret name can vary, but the password key must be redis-password.
     # existingSecret: paperless-redis
     # existingSecretPasswordKey: redis-password

--- a/charts/paperless-ngx/values.yaml
+++ b/charts/paperless-ngx/values.yaml
@@ -123,8 +123,8 @@ redis:
   auth:
     enabled: true
     # Use an existing secret for redis auth. Do this if you're using Argo to manage your instance or otherwise converting helm to kustomize under the hood
-    #     Make sure to use the exact names below.
-    # existingSecret: tahiti-redis
+    #     The secret name can vary, but the password key must be redis-password.
+    # existingSecret: paperless-redis
     # existingSecretPasswordKey: redis-password
   master:
     persistence:


### PR DESCRIPTION
When using Argo to manage a paperless-ngx helm chart with redis auth enabled, at periodic intervals the redis password and paperless-ngx password will get out of sync, leading to failures to process documents. Killing the redis and paperless-ngx pods simultaneously will resolve this issue. However, it's a frustrating thing to have happen on a periodic basis.

Using an existing secret should prevent this issue from happening.
The [Bitnami package for redis](https://github.com/bitnami/charts/tree/main/bitnami/redis) is the root of this issue (although, to be fair, I hardly think they were considering things like Argo doing funky templating conversions to Kustomize when they designed their chart).

Specifically, I *believe* when the Bitnami chart [reads in the existing secret](https://github.com/bitnami/charts/blob/4b26e83a5e928039c0975b64a8b9b4f0049a4783/bitnami/redis/templates/_helpers.tpl#L250) it does so in a way that fails to recognize existing passwords after converted to Kustomize by Argo. This means that when Argo recreates the redis pod it always regenerates the password, unbeknownst to the paperless-ngx pod, which still has the last generated password it was aware of, hence the transient out-of-sync issues.

Regardless, there may be other reasons someone would want to use their own password for redis auth, and this will save them some time digging around in the sub-chart.
If adding sub-chart configuration comments for configuration is an antipattern (and users should always be checking the sub-chart directly) feel free to reject this, no worries.