### PR TITLE
fix(paperless-ngx): Allow redis username to be overridden

### DIFF
--- a/charts/paperless-ngx/templates/common.yaml
+++ b/charts/paperless-ngx/templates/common.yaml
@@ -40,7 +40,7 @@ env:
     secretKeyRef:
       name: {{ $.Release.Name }}-redis
       key: redis-password
-  PAPERLESS_REDIS: redis://:$(A_REDIS_PASSWORD)@{{ $.Release.Name }}-redis-master
+  PAPERLESS_REDIS: redis://{{ .auth.username }}:$(A_REDIS_PASSWORD)@{{ $.Release.Name }}-redis-master
   {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/paperless-ngx/values.yaml
+++ b/charts/paperless-ngx/values.yaml
@@ -122,6 +122,7 @@ redis:
   enabled: true
   auth:
     enabled: true
+    username: ""
     # Use an existing secret for redis auth. Do this if you're using Argo to manage your instance or otherwise using helm template under the hood
     #     The secret name can vary, but the password key must be redis-password.
     # existingSecret: paperless-redis


### PR DESCRIPTION
As described in https://github.com/gabe565/charts/issues/551, under certain circumstances the redis connection seems to not work with the current chart due to an empty username in the redis connection string.  
This PR would allow users to override the redis username (in my case, supplying `default` works), with an empty string remaining the default value.