### PR TITLE
Fix vaultwarden subchart URLs, revise references to master branch for bitnami/charts repo

### DIFF
--- a/charts/bookstack/README.md
+++ b/charts/bookstack/README.md
@@ -91,7 +91,7 @@ N/A
 | image.repository | string | `"ghcr.io/linuxserver/bookstack"` | image repository |
 | image.tag | string | `"version-v24.05.1"` | image tag |
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
-| mariadb | object | See [values.yaml](./values.yaml) | Enable and configure mariadb database subchart under this key.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) |
+| mariadb | object | See [values.yaml](./values.yaml) | Enable and configure mariadb database subchart under this key.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/mariadb) |
 | persistence.config | object | See [values.yaml](./values.yaml) | Configure persistence settings for the chart under this key. |
 | podSecurityContext.fsGroup | int | `911` | Volume group permissions |
 | service | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |

--- a/charts/bookstack/values.yaml
+++ b/charts/bookstack/values.yaml
@@ -51,7 +51,7 @@ persistence:
      # size: 1Gi
 
 # -- Enable and configure mariadb database subchart under this key.
-#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/mariadb)
 # @default -- See [values.yaml](./values.yaml)
 mariadb:
   enabled: false

--- a/charts/gotify/README.md
+++ b/charts/gotify/README.md
@@ -98,7 +98,7 @@ N/A
 | podSecurityContext.fsGroup | int | `65534` | Volume binds will be granted to `nobody` group |
 | podSecurityContext.runAsGroup | int | `65534` | Run as `nobody` group |
 | podSecurityContext.runAsUser | int | `65534` | Run as `nobody` user |
-| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    [[ref]](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
+| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) |
 | service | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |
 
 ---

--- a/charts/gotify/values.yaml
+++ b/charts/gotify/values.yaml
@@ -67,7 +67,7 @@ podSecurityContext:
   fsGroup: 65534
 
 # -- Enable and configure postgresql database subchart under this key.
-#    [[ref]](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+#    [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
 # @default -- See [values.yaml](./values.yaml)
 postgresql:
   enabled: false

--- a/charts/headscale/README.md
+++ b/charts/headscale/README.md
@@ -155,7 +155,7 @@ Once deployed, the UI will be available at `/web`.
 | image.tag | string | `"0.22.3"` | image tag |
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
 | persistence.config | object | See [values.yaml](./values.yaml) | Configure persistence settings for the chart under this key. |
-| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
+| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) |
 | service.main | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |
 | serviceMonitor.main.enabled | bool | `false` | Enables or disables the serviceMonitor. |
 | serviceMonitor.main.endpoints | list | See [values.yaml](./values.yaml) | Configures the endpoints for the serviceMonitor. |

--- a/charts/headscale/values.yaml
+++ b/charts/headscale/values.yaml
@@ -75,7 +75,7 @@ persistence:
     # size: 1Gi
 
 # -- Enable and configure postgresql database subchart under this key.
-#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
 # @default -- See [values.yaml](./values.yaml)
 postgresql:
   enabled: false

--- a/charts/healthchecks/README.md
+++ b/charts/healthchecks/README.md
@@ -100,9 +100,9 @@ See each database section in [`values.yaml`](./values.yaml) for configuration ex
 | image.repository | string | `"ghcr.io/linuxserver/healthchecks"` | Image repository |
 | image.tag | string | `"version-v3.3"` | Image tag |
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
-| mariadb | object | See [values.yaml](./values.yaml) | Enable and configure mariadb database subchart under this key.    If enabled, the app's db envs will be set for you.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) |
+| mariadb | object | See [values.yaml](./values.yaml) | Enable and configure mariadb database subchart under this key.    If enabled, the app's db envs will be set for you.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/mariadb) |
 | persistence.config | object | See [values.yaml](./values.yaml) | Configure persistence settings for the chart under this key.    Necessary for SQLite. |
-| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    If enabled, the app's db envs will be set for you.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
+| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    If enabled, the app's db envs will be set for you.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) |
 | service.main | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |
 
 ---

--- a/charts/healthchecks/values.yaml
+++ b/charts/healthchecks/values.yaml
@@ -63,7 +63,7 @@ persistence:
 
 # -- Enable and configure postgresql database subchart under this key.
 #    If enabled, the app's db envs will be set for you.
-#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
 # @default -- See [values.yaml](./values.yaml)
 postgresql:
   enabled: false
@@ -78,7 +78,7 @@ postgresql:
 
 # -- Enable and configure mariadb database subchart under this key.
 #    If enabled, the app's db envs will be set for you.
-#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/mariadb)
 # @default -- See [values.yaml](./values.yaml)
 mariadb:
   enabled: false

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -144,7 +144,7 @@ No extra privileges required!
 | image.tag | string | `"latest"` | image tag |
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
 | persistence.config | object | See [values.yaml](./values.yaml) | Configure persistence settings for the chart under this key. |
-| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
+| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) |
 | service | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |
 
 ---

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -58,7 +58,7 @@ persistence:
     # size: 1Gi
 
 # -- Enable and configure postgresql database subchart under this key.
-#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
 # @default -- See [values.yaml](./values.yaml)
 postgresql:
   enabled: false

--- a/charts/limo/README.md
+++ b/charts/limo/README.md
@@ -91,7 +91,7 @@ N/A
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
 | persistence.data | object | See [values.yaml](./values.yaml) | Configure persistence settings for the chart under this key. |
 | podSecurityContext.fsGroup | int | `1000` | Volume group permissions |
-| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
+| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) |
 | service | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |
 
 ---

--- a/charts/limo/values.yaml
+++ b/charts/limo/values.yaml
@@ -58,7 +58,7 @@ persistence:
     # size: 1Gi
 
 # -- Enable and configure postgresql database subchart under this key.
-#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
 # @default -- See [values.yaml](./values.yaml)
 postgresql:
   enabled: false

--- a/charts/memos/README.md
+++ b/charts/memos/README.md
@@ -90,12 +90,12 @@ N/A
 | image.repository | string | `"ghcr.io/usememos/memos"` | image repository |
 | image.tag | string | `"0.22.1"` | image tag |
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
-| mariadb | object | See [values.yaml](./values.yaml) | Enable and configure mariadb database subchart under this key.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) |
+| mariadb | object | See [values.yaml](./values.yaml) | Enable and configure mariadb database subchart under this key.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/mariadb) |
 | persistence | object | See [values.yaml](./values.yaml) | Configure persistence settings for the chart under this key. |
 | podSecurityContext.fsGroup | int | `65534` | Volume binds will be granted to `nobody` group |
 | podSecurityContext.runAsGroup | int | `65534` | Run as `nobody` group |
 | podSecurityContext.runAsUser | int | `65534` | Run as `nobody` user |
-| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
+| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) |
 | service | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |
 
 ---

--- a/charts/memos/values.yaml
+++ b/charts/memos/values.yaml
@@ -56,7 +56,7 @@ podSecurityContext:
   fsGroup: 65534
 
 # -- Enable and configure postgresql database subchart under this key.
-#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
 # @default -- See [values.yaml](./values.yaml)
 postgresql:
   enabled: false
@@ -70,7 +70,7 @@ postgresql:
       # size: 8Gi
 
 # -- Enable and configure mariadb database subchart under this key.
-#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/mariadb)
 # @default -- See [values.yaml](./values.yaml)
 mariadb:
   enabled: false

--- a/charts/miniflux/README.md
+++ b/charts/miniflux/README.md
@@ -95,7 +95,7 @@ N/A
 | image.repository | string | `"ghcr.io/miniflux/miniflux"` | image repository |
 | image.tag | string | `"2.1.3"` | image tag |
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
-| postgresql | object | Enabled (See [values.yaml](./values.yaml) for more details) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
+| postgresql | object | Enabled (See [values.yaml](./values.yaml) for more details) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) |
 | service.main | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |
 | serviceMonitor.main.allowedNetworks | string | `"127.0.0.1/8"` | List of networks allowed to access the `/metrics` endpoint (comma-separated values).    [[ref]](https://miniflux.app/docs/configuration.html#metrics-allowed-networks) |
 | serviceMonitor.main.enabled | bool | `false` | Enables or disables the serviceMonitor. |

--- a/charts/miniflux/values.yaml
+++ b/charts/miniflux/values.yaml
@@ -52,7 +52,7 @@ ingress:
     #       - chart-example.local
 
 # -- Enable and configure postgresql database subchart under this key.
-#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
 # @default -- Enabled (See [values.yaml](./values.yaml) for more details)
 postgresql:
   enabled: true

--- a/charts/monica/README.md
+++ b/charts/monica/README.md
@@ -93,7 +93,7 @@ N/A
 | image.repository | string | `"monica"` | image repository |
 | image.tag | string | `"4.1.2-fpm-alpine"` | image tag |
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
-| mariadb | object | See [values.yaml](./values.yaml) | Enable and configure mariadb database subchart under this key.    [[ref]](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) |
+| mariadb | object | See [values.yaml](./values.yaml) | Enable and configure mariadb database subchart under this key.    [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/mariadb) |
 | nginx.enabled | bool | `true` | Enable the Nginx sidecar.    Disable this if you use an apache image. |
 | nginx.image.pullPolicy | string | `"Always"` | Nginx image pull policy |
 | nginx.image.repository | string | `"nginx"` | Nginx image repository |

--- a/charts/monica/values.yaml
+++ b/charts/monica/values.yaml
@@ -62,7 +62,7 @@ persistence:
     # size: 1Gi
 
 # -- Enable and configure mariadb database subchart under this key.
-#    [[ref]](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+#    [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/mariadb)
 # @default -- See [values.yaml](./values.yaml)
 mariadb:
   enabled: false

--- a/charts/nightscout/README.md
+++ b/charts/nightscout/README.md
@@ -94,7 +94,7 @@ N/A
 | image.repository | string | `"nightscout/cgm-remote-monitor"` | image repository |
 | image.tag | string | `"15.0.2"` | image tag |
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
-| mongodb | object | See [values.yaml](./values.yaml) | Enable and configure mongodb database subchart under this key.    For more options see [mongodb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mongodb) |
+| mongodb | object | See [values.yaml](./values.yaml) | Enable and configure mongodb database subchart under this key.    For more options see [mongodb chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/mongodb) |
 | service.main | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |
 
 ---

--- a/charts/nightscout/values.yaml
+++ b/charts/nightscout/values.yaml
@@ -49,7 +49,7 @@ ingress:
     #       - chart-example.local
 
 # -- Enable and configure mongodb database subchart under this key.
-#    For more options see [mongodb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mongodb)
+#    For more options see [mongodb chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/mongodb)
 # @default -- See [values.yaml](./values.yaml)
 mongodb:
   enabled: false

--- a/charts/obico/README.md
+++ b/charts/obico/README.md
@@ -96,7 +96,7 @@ N/A
 | podSecurityContext.fsGroup | int | `65534` | Volume binds will be granted to `nobody` group |
 | podSecurityContext.runAsGroup | int | `65534` | Run as `nobody` group |
 | podSecurityContext.runAsUser | int | `65534` | Run as `nobody` user |
-| redis | object | See [values.yaml](./values.yaml) | Enable and configure redis subchart under this key. [[ref]](https://github.com/bitnami/charts/tree/master/bitnami/redis) |
+| redis | object | See [values.yaml](./values.yaml) | Enable and configure redis subchart under this key. [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/redis) |
 | server.additionalContainers.tasks.command | list | See [values.yaml](./values.yaml) | Task command. |
 | server.command | list | See [values.yaml](./values.yaml) | Command to run Obico server. |
 | server.env | string | See [values.yaml](./values.yaml) | Server environment variables. [[ref]](https://github.com/TheSpaghettiDetective/obico-server/blob/master/dotenv.example) |

--- a/charts/obico/values.yaml
+++ b/charts/obico/values.yaml
@@ -174,7 +174,7 @@ podSecurityContext:
   # -- Volume binds will be granted to `nobody` group
   fsGroup: 65534
 
-# -- Enable and configure redis subchart under this key. [[ref]](https://github.com/bitnami/charts/tree/master/bitnami/redis)
+# -- Enable and configure redis subchart under this key. [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/redis)
 # @default -- See [values.yaml](./values.yaml)
 redis:
   enabled: true

--- a/charts/rsshub/README.md
+++ b/charts/rsshub/README.md
@@ -91,7 +91,7 @@ N/A
 | image.repository | string | `"diygod/rsshub"` | image repository |
 | image.tag | string | `"latest"` | image tag |
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
-| redis | object | See [values.yaml](./values.yaml) | Enable and configure redis subchart under this key.    For more options see [redis chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/redis) |
+| redis | object | See [values.yaml](./values.yaml) | Enable and configure redis subchart under this key.    For more options see [redis chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/redis) |
 | service | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |
 
 ---

--- a/charts/rsshub/values.yaml
+++ b/charts/rsshub/values.yaml
@@ -45,7 +45,7 @@ ingress:
     #       - chart-example.local
 
 # -- Enable and configure redis subchart under this key.
-#    For more options see [redis chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/redis)
+#    For more options see [redis chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/redis)
 # @default -- See [values.yaml](./values.yaml)
 redis:
   enabled: true

--- a/charts/tandoor/README.md
+++ b/charts/tandoor/README.md
@@ -95,7 +95,7 @@ N/A
 | podSecurityContext.fsGroup | int | `65534` | Volume binds will be granted to `nobody` group |
 | podSecurityContext.runAsGroup | int | `65534` | Run as `nobody` group |
 | podSecurityContext.runAsUser | int | `65534` | Run as `nobody` user |
-| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key. [[ref]](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) |
+| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key. [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/mariadb) |
 | service.main | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. |
 
 ---

--- a/charts/tandoor/values.yaml
+++ b/charts/tandoor/values.yaml
@@ -72,7 +72,7 @@ persistence:
     type: emptyDir
     mountPath: /opt/recipes/cookbook/static/django_js_reverse
 
-# -- Enable and configure postgresql database subchart under this key. [[ref]](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+# -- Enable and configure postgresql database subchart under this key. [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/mariadb)
 # @default -- See [values.yaml](./values.yaml)
 postgresql:
   enabled: false

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -102,12 +102,12 @@ persistence:
 | image.repository | string | `"ghcr.io/dani-garcia/vaultwarden"` | image repository |
 | image.tag | string | `"1.30.5-alpine"` | image tag |
 | ingress.main | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
-| mariadb | object | See [values.yaml](./values.yaml) | Enable and configure mariadb database subchart under this key.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) |
+| mariadb | object | See [values.yaml](./values.yaml) | Enable and configure mariadb database subchart under this key.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/mariadb) |
 | persistence.data | object | See [values.yaml](./values.yaml) | Configure persistence settings for the chart under this key. |
 | podSecurityContext.fsGroup | int | `65534` | Volume binds will be granted to `nobody` group |
 | podSecurityContext.runAsGroup | int | `65534` | Run as `nobody` group |
 | podSecurityContext.runAsUser | int | `65534` | Run as `nobody` user |
-| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) |
+| postgresql | object | See [values.yaml](./values.yaml) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) |
 | service.main | object | See [values.yaml](./values.yaml) | Configures service settings for the chart. Normally this does not need to be modified. |
 
 ---

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -57,7 +57,7 @@ persistence:
     # size: 1Gi
 
 # -- Enable and configure postgresql database subchart under this key.
-#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
 # @default -- See [values.yaml](./values.yaml)
 postgresql:
   enabled: false
@@ -71,7 +71,7 @@ postgresql:
       # size: 8Gi
 
 # -- Enable and configure mariadb database subchart under this key.
-#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/mariadb)
 # @default -- See [values.yaml](./values.yaml)
 mariadb:
   enabled: false


### PR DESCRIPTION
### Description
While reading through the documentation for the vaultwarden chart I noticed that the postgresql subchart links to the mariadb subchart instead. This main fix for this updates the incorrect URL linking in the vaultwarden chart values, and README files.

Also, it does appear that the [bitnami/charts](https://github.com/bitnami/charts) repository has renamed their `master` branch to `main`. The existing URLs still work, however, you will be greeted by this banner after opening the outdated link.

![screenshot](https://github.com/user-attachments/assets/1e7bc6e0-69a0-49d0-95f5-b56730655aa7)

While I was updating URLs I figured it would be worth updating all of the references to the outdated branch name.