### PR TITLE
chore(vaultwarden): update common chart to v3.5.1

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -17,7 +17,7 @@ sources:
 dependencies:
   - name: common
     repository: https://bjw-s.github.io/helm-charts
-    version: 1.5.1
+    version: 3.5.1
   - name: mariadb
     version: 16.0.2
     repository: https://charts.bitnami.com/bitnami

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -25,7 +25,7 @@ Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| <https://bjw-s.github.io/helm-charts> | common | 1.5.1 |
+| <https://bjw-s.github.io/helm-charts> | common | 3.5.1 |
 | <https://charts.bitnami.com/bitnami> | mariadb | 16.0.2 |
 | <https://charts.bitnami.com/bitnami> | postgresql | 14.0.5 |
 
@@ -60,7 +60,7 @@ The command removes all the Kubernetes components associated with the chart **in
 ## Configuration
 
 Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
-Other values may be used from the [values.yaml](https://github.com/bjw-s/helm-charts/tree/a081de5/charts/library/common/values.yaml) from the [bjw-s common library](https://github.com/bjw-s/helm-charts/tree/a081de5/charts/library/common).
+Other values may be used from the [values.yaml](https://github.com/bjw-s/helm-charts/tree/main/charts/library/common/values.yaml) from the [bjw-s common library](https://github.com/bjw-s/helm-charts/tree/main/charts/library/common).
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -91,7 +91,7 @@ persistence:
 
 ## Values
 
-**Important**: When deploying an application Helm chart you can add more values from the bjw-s common library chart [here](https://github.com/bjw-s/helm-charts/tree/a081de5/charts/library/common)
+**Important**: When deploying an application Helm chart you can add more values from the bjw-s common library chart [here](https://github.com/bjw-s/helm-charts/tree/main/charts/library/common)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|


### PR DESCRIPTION
I noticed the common chart version is pretty outdated.

Btw, I couldn't get the `gen-chart-summary` pre-commit hook working: 
```

$ gc -m'chore(vaultwarden): update common chart to v3.5.1'
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
fix utf-8 byte order marker..............................................Passed
mixed line ending........................................................Passed
check for merge conflicts................................................Passed
check for case conflicts.................................................Passed
CRLF end-lines remover...................................................Passed
Tabs remover.............................................................Passed
Artifact Hub Lint........................................................Passed
Helm Docs................................................................Passed
Generate Chart Summary...................................................Failed
- hook id: gen-chart-summary
- exit code: 2

sed: can't read /^## Chart Overview$/,$d: No such file or directory
```