### PR TITLE
Set python path to dependencies needed for HACS

### DIFF
--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -18,6 +18,8 @@ image:
 env:
   # -- Set the container timezone
   TZ: UTC
+  # -- Set PYTHONPATH so that HACS finds it's dependencies
+  PYTHONPATH: "/config/deps"
 
 # -- Configures service settings for the chart.
 # @default -- See [values.yaml](./values.yaml)


### PR DESCRIPTION
Set Python Path to new installation Path of uv installed dependencies since HA 2024.10.1

Since the switch from pip to uv dependencies installed for integrations installed through HACS will end up in /config/deps instead of /config/deps/lib/pythonX.YY/site-packages/ like before. Python still looks in the site-packages folder so for integrations where the deps have changed since ~HA 2014.10.1 that might lead to non-functioning integrations.
This appears to be an issue for deployments on K8s only but not limited to this chart.
I am unaware if there are upstream changes coming, that will solve this, but since this is not an issue with HAOS or Docker deployments I'd guess no.

See for instance: [https://github.com/home-assistant/core/issues/127966](https://github.com/home-assistant/core/issues/127966
)

Disclaimer: I am not sure if this is only a workaround for issues or a long-term solutions and I don't want to say that the switch from pip to uv is the root cause of the troubles.
