### PR TITLE
Bumped bitnami/redis to 20.3.0 to support arm64 architecture

### DIFF
--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     condition: mariadb.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 18.6.4
+    version: 20.3.0
     condition: redis.enabled
 sources:
   - https://github.com/paperless-ngx/paperless-ngx


### PR DESCRIPTION
Hey, 
i tried to run paperless-ngx on a raspberry pi k3s cluster and it mostly works. The only problem was an older version of redis which was not compatible with arm64. Switching to the latest version works fine and resolves the issue. 

Cheers
Dennis