### PR TITLE
paperless-ngx: allow for custom db secrets name

### DIFF
--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -4,7 +4,7 @@ description: "A community-supported supercharged version of paperless: scan, ind
 home: https://charts.gabe565.com/charts/paperless-ngx/
 icon: https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/b948750/src-ui/src/assets/logo-notext.svg
 type: application
-version: 0.24.0
+version: 0.24.1
 # renovate datasource=docker depName=ghcr.io/paperless-ngx/paperless-ngx
 appVersion: 2.14.7
 kubeVersion: ">=1.22.0-0"

--- a/charts/paperless-ngx/templates/common.yaml
+++ b/charts/paperless-ngx/templates/common.yaml
@@ -18,7 +18,7 @@ env:
   PAPERLESS_DBUSER: {{ default "postgres" .auth.username }}
   PAPERLESS_DBPASS:
     secretKeyRef:
-      name: {{ $.Release.Name }}-postgresql
+      name: {{ .auth.existingSecret | default (printf "%s-postgresql" $.Release.Name) }}
       key: {{ if not .auth.password }}postgres-{{ end }}password
   {{- end }}
   {{- else if .Values.mariadb.enabled }}
@@ -29,7 +29,7 @@ env:
   PAPERLESS_DBUSER: {{ .auth.username }}
   PAPERLESS_DBPASS:
     secretKeyRef:
-      name: {{ $.Release.Name }}-mariadb
+      name: {{ .auth.existingSecret | default (printf "%s-mariadb" $.Release.Name) }}
       key: mariadb-password
   {{- end }}
   {{- end }}
@@ -38,16 +38,8 @@ env:
   {{- with .Values.redis }}
   A_REDIS_PASSWORD:
     secretKeyRef:
-      {{- if .auth.existingSecret }}
-      name: {{ .auth.existingSecret }}
-      {{- else }}
-      name: {{ $.Release.Name }}-redis
-      {{- end }}
-      {{- if .auth.existingSecretPasswordKey }}
-      name: {{ .auth.existingSecretPasswordKey }}
-      {{- else }}
-      key: redis-password
-      {{- end }}
+      name: {{ .auth.existingSecret | default (printf "%s-redis" $.Release.Name) }}
+      key: {{ .auth.existingSecretPasswordKey | default "redis-password" }}
   PAPERLESS_REDIS: redis://{{ .auth.username }}:$(A_REDIS_PASSWORD)@{{ $.Release.Name }}-redis-master
   {{- end }}
   {{- end }}

--- a/charts/paperless-ngx/templates/common.yaml
+++ b/charts/paperless-ngx/templates/common.yaml
@@ -38,8 +38,16 @@ env:
   {{- with .Values.redis }}
   A_REDIS_PASSWORD:
     secretKeyRef:
+      {{- if .auth.existingSecret }}
+      name: {{ .auth.existingSecret }}
+      {{- else }}
       name: {{ $.Release.Name }}-redis
+      {{- end }}
+      {{- if .auth.existingSecretPasswordKey }}
+      name: {{ .auth.existingSecretPasswordKey }}
+      {{- else }}
       key: redis-password
+      {{- end }}
   PAPERLESS_REDIS: redis://{{ .auth.username }}:$(A_REDIS_PASSWORD)@{{ $.Release.Name }}-redis-master
   {{- end }}
   {{- end }}


### PR DESCRIPTION
ciao, I'm using your chart with argo and custom secrets but I've noticed I'm not really free to choose the secrets I want as their name sticks to subchart's `$.Release.name` in paperless-ngx pod config:

```yaml

# .secretKeyRef.name differ in redis' sts and paperless-ngx deployment

# redis sts
helm template paperless-ngx . \
  --set persistence.consume.accessMode=ReadWriteOnce \
  --set persistence.consume.size=1Gi \
  --set persistence.export.accessMode=ReadWriteOnce \
  --set persistence.export.size=1Gi \
  --set redis.auth.existingSecret=my-redis-secret \
  -s charts/redis/templates/master/application.yaml \
  | yq -Y '
    select(.metadata.name=="paperless-ngx-redis-master")
    .spec.template.spec.containers[] .env'

[...]
- name: REDIS_PASSWORD
  valueFrom:
    secretKeyRef:
      name: my-redis-secret
      key: redis-password

# paperless-ngx deployment
helm template paperless-ngx . \
  --set persistence.consume.accessMode=ReadWriteOnce \
  --set persistence.consume.size=1Gi \
  --set persistence.export.accessMode=ReadWriteOnce \
  --set persistence.export.size=1Gi \
  --set redis.auth.existingSecret=my-redis-secret \
  -s templates/common.yaml \
  | yq -Y '
    select(.metadata.name=="paperless-ngx" and .kind=="Deployment") 
    .spec.template.spec.containers[] .env'

[...]
- name: A_REDIS_PASSWORD
  valueFrom:
    secretKeyRef:
      key: redis-password
      name: paperless-ngx-redis
```

 This little PR fix this:

```yaml
# redis sts
helm template paperless-ngx . \
  --set persistence.consume.accessMode=ReadWriteOnce \
  --set persistence.consume.size=1Gi \
  --set persistence.export.accessMode=ReadWriteOnce \
  --set persistence.export.size=1Gi \
  --set redis.auth.existingSecret=my-redis-secret \
  -s charts/redis/templates/master/application.yaml \
  | yq -Y '
    select(.metadata.name=="paperless-ngx-redis-master")
    .spec.template.spec.containers[] .env'

[...]
- name: REDIS_PASSWORD
  valueFrom:
    secretKeyRef:
      name: my-redis-secret
      key: redis-password

# paperless-ngx deployment
helm template paperless-ngx . \
  --set persistence.consume.accessMode=ReadWriteOnce \
  --set persistence.consume.size=1Gi \
  --set persistence.export.accessMode=ReadWriteOnce \
  --set persistence.export.size=1Gi \
  --set redis.auth.existingSecret=my-redis-secret \
  -s templates/common.yaml \
  | yq -Y '
    select(.metadata.name=="paperless-ngx" and .kind=="Deployment")
    .spec.template.spec.containers[] .env'

[...]
- name: A_REDIS_PASSWORD
  valueFrom:
    secretKeyRef:
      key: redis-password
      name: my-redis-secret
```

for psql, mariadb and redis password.

Hope this helps, thank you for your work, regards