### PR TITLE
adguard - Update exposed port to 80

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -4,7 +4,7 @@ description: Free and open source, powerful network-wide ads & trackers blocking
 home: https://charts.gabe565.com/charts/adguard-home/
 icon: https://raw.githubusercontent.com/gabe565/charts/main/charts/adguard-home/icon.svg
 type: application
-version: 0.3.25
+version: 0.3.26
 # renovate datasource=docker depName=adguard/adguardhome
 appVersion: v0.107.56
 kubeVersion: ">=1.22.0-0"

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -23,7 +23,7 @@ service:
   main:
     ports:
       http:
-        port: 3000
+        port: 80
   # -- Configures settings for the TCP DNS service.
   # @default -- See [values.yaml](./values.yaml)
   dns-tcp:


### PR DESCRIPTION
Hello, 

I noticed a small error in the chart. The adguard configuration uses port 80 for webui, but the default port used is 3000 in the chart.

This PR corrects this mismatch 😄 