### PR TITLE
[qBittorrent] Bump bjw-s common chart version to 3.7.x

### DIFF
--- a/charts/qbittorrent/Chart.lock
+++ b/charts/qbittorrent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://bjw-s.github.io/helm-charts
-  version: 1.5.1
-digest: sha256:3588c89621170f198d4938664d3ea4c469bd91fd78183c83cfcf63f474d348c4
-generated: "2023-08-06T06:19:47.992738822Z"
+  version: 3.7.3
+digest: sha256:86fab71cc642322d6892cc8f1c7bbf7ed56ac8790c9c465ec266ee6011903353
+generated: "2025-03-30T12:58:19.241028+02:00"

--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -4,7 +4,7 @@ description: The qBittorrent project aims to provide an open-source software alt
 home: https://charts.gabe565.com/charts/qbittorrent/
 icon: https://raw.githubusercontent.com/qbittorrent/qBittorrent/master/src/icons/qbittorrent-tray.svg
 type: application
-version: 0.4.1
+version: 0.5.0
 # renovate datasource=docker depName=ghcr.io/linuxserver/qbittorrent
 appVersion: version-5.0.3-r0
 kubeVersion: ">=1.22.0-0"
@@ -14,7 +14,7 @@ keywords:
 dependencies:
   - name: common
     repository: https://bjw-s.github.io/helm-charts
-    version: 1.5.1
+    version: ~3.7.3
 sources:
   - https://github.com/qbittorrent/qBittorrent
   - https://github.com/linuxserver/docker-qbittorrent

--- a/charts/qbittorrent/README.md
+++ b/charts/qbittorrent/README.md
@@ -26,7 +26,7 @@ Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| <https://bjw-s.github.io/helm-charts> | common | 1.5.1 |
+| <https://bjw-s.github.io/helm-charts> | common | ~3.7.3 |
 
 ## Installing the Chart
 

--- a/charts/qbittorrent/templates/NOTES.txt
+++ b/charts/qbittorrent/templates/NOTES.txt
@@ -1,1 +1,0 @@
-{{- include "bjw-s.common.lib.chart.notes" . -}}

--- a/charts/qbittorrent/values.yaml
+++ b/charts/qbittorrent/values.yaml
@@ -4,30 +4,38 @@
 # This chart inherits from our common library chart. You can check the default values/options here:
 # https://github.com/bjw-s/helm-charts/blob/a081de5/charts/library/common/values.yaml
 #
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/app-template-3.7.3/charts/other/app-template/values.schema.json
 
-image:
-  # -- image repository
-  repository: ghcr.io/linuxserver/qbittorrent
-  # -- image pull policy
-  pullPolicy: IfNotPresent
-  # -- image tag
-  tag: version-5.0.3-r0
+controllers:
+  qbittorrent:
+    containers:
+      main:
+        image:
+          # -- image repository
+          repository: ghcr.io/linuxserver/qbittorrent
+          # -- image pull policy
+          pullPolicy: IfNotPresent
+          # -- image tag
+          tag: version-5.0.3-r0
 
-# -- environment variables. [[ref]](https://github.com/linuxserver/docker-qbittorrent#parameters)
-# @default -- See [values.yaml](./values.yaml)
-env:
-  # -- Set the container timezone
-  TZ: UTC
+        # -- environment variables. [[ref]](https://github.com/linuxserver/docker-qbittorrent#parameters)
+        # @default -- See [values.yaml](./values.yaml)
+        env:
+          # -- Set the container timezone
+          TZ: UTC
 
 # -- Configures service settings for the chart.
 # @default -- See [values.yaml](./values.yaml)
 service:
   main:
+    controller: qbittorrent
     ports:
-      http:
+      webui:
         port: 8080
   bittorrent:
     enabled: false
+    controller: qbittorrent
     ports:
       bittorrent:
         enabled: true
@@ -39,10 +47,14 @@ ingress:
   # @default -- See [values.yaml](./values.yaml)
   main:
     enabled: false
+    hosts: []
     # hosts:
     #   - host: chart-example.local
     #     paths:
     #       - path: /
+    #         service:
+    #           identifier: main
+    #           port: webui
     # tls:
     #   - secretName: chart-example.local-tls
     #     hosts:


### PR DESCRIPTION
Hi 👋 

I noticed that the BJW-S common Helm chart dependency was a bit out-of-date while trying to deploy qBittorrent with an NFS mount point described as an existing `PersistentVolumeClaim` (useful to add some NFS mount options).

This pull request proposes an update of this chart dependency with a few changes as it's a major version bump such as:
- a new `values.yaml` organization
- a different way of defining the dependency's version to allow for minor and patch updates to be pulled automatically during updates
- the deletion of the `NOTES.txt` file as the new BJW-S common chart doesn't seem to support notes generation

I've tested everything with a basic `values.yaml` file I wrote for my home lab and with the `helm template` command, everything seems to work fine ✅ 