### PR TITLE
Miniflux: Allow customising the healthcheck path

### DIFF
--- a/charts/miniflux/templates/common.yaml
+++ b/charts/miniflux/templates/common.yaml
@@ -24,7 +24,7 @@
       custom: true
       spec:
         httpGet:
-          path: /healthcheck
+          path: {{ .Values.service.main.probes.livenessProbe.path }}
           port: {{ .Values.service.main.ports.http.port }}
 {{- end -}}
 {{- $_ := merge .Values (include "miniflux.harcodedValues" . | fromYaml) -}}

--- a/charts/miniflux/values.yaml
+++ b/charts/miniflux/values.yaml
@@ -36,6 +36,11 @@ service:
     ports:
       http:
         port: 8080
+    probes:
+      livenessProbe:
+        # -- You will to set this to a path under BASE_URL, if you set one.
+        #    i.e. if you set BASE_URL to https://my.server/rss then this needs to be /rss/healthcheck
+        path: /healthcheck
 
 ingress:
   # -- Enable and configure ingress settings for the chart under this key.


### PR DESCRIPTION
This is necessary when setting a BASE_URL that has a path component, as miniflux also shunts its /healthcheck endpoint under there.