### PR TITLE
switches paperless-chart from bitnami to cloudpirates repos

### DIFF
--- a/charts/paperless-ngx/Chart.lock
+++ b/charts/paperless-ngx/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: common
-  repository: https://bjw-s.github.io/helm-charts
+  repository: https://bjw-s-labs.github.io/helm-charts
   version: 1.5.1
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 14.0.5
+- name: postgres
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.12.0
 - name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 20.1.1
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.6.1
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 20.7.0
-digest: sha256:393ade0c071a39f76cc62844ef6d14d85eeb674f099de016e1adac207f04d643
-generated: "2025-02-04T16:09:39.211839317Z"
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.14.1
+digest: sha256:3469991b6bd150085ece625886d62bc40688e40c8557824ce0c1758472df8f95
+generated: "2025-11-15T11:08:44.798343772+01:00"

--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -4,7 +4,7 @@ description: "A community-supported supercharged version of paperless: scan, ind
 home: https://charts.gabe565.com/charts/paperless-ngx/
 icon: https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/b948750/src-ui/src/assets/logo-notext.svg
 type: application
-version: 0.24.1
+version: 0.25.0
 # renovate datasource=docker depName=ghcr.io/paperless-ngx/paperless-ngx
 appVersion: 2.14.7
 kubeVersion: ">=1.22.0-0"
@@ -14,19 +14,19 @@ keywords:
   - paper
 dependencies:
   - name: common
-    repository: https://bjw-s.github.io/helm-charts
+    repository: https://bjw-s-labs.github.io/helm-charts
     version: 1.5.1
-  - name: postgresql
-    version: 14.0.5
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled
+  - name: postgres
+    version: 0.12.0
+    repository: oci://registry-1.docker.io/cloudpirates
+    condition: postgres.enabled
   - name: mariadb
-    version: 20.1.1
-    repository: https://charts.bitnami.com/bitnami
+    version: 0.6.1
+    repository: oci://registry-1.docker.io/cloudpirates
     condition: mariadb.enabled
   - name: redis
-    repository: https://charts.bitnami.com/bitnami
-    version: 20.7.0
+    repository: oci://registry-1.docker.io/cloudpirates
+    version: 0.14.1
     condition: redis.enabled
 sources:
   - https://github.com/paperless-ngx/paperless-ngx

--- a/charts/paperless-ngx/templates/common.yaml
+++ b/charts/paperless-ngx/templates/common.yaml
@@ -10,16 +10,16 @@ env:
   {{- end }}
   {{- end }}
 
-  {{- if .Values.postgresql.enabled }}
-  {{- with .Values.postgresql }}
+  {{- if .Values.postgres.enabled }}
+  {{- with .Values.postgres }}
   PAPERLESS_DBENGINE: postgresql
-  PAPERLESS_DBHOST: {{ $.Release.Name }}-postgresql
+  PAPERLESS_DBHOST: {{ $.Release.Name }}-postgres
   PAPERLESS_DBNAME: {{ .auth.database }}
   PAPERLESS_DBUSER: {{ default "postgres" .auth.username }}
   PAPERLESS_DBPASS:
     secretKeyRef:
-      name: {{ .auth.existingSecret | default (printf "%s-postgresql" $.Release.Name) }}
-      key: {{ if not .auth.password }}postgres-{{ end }}password
+      name: {{ .auth.existingSecret | default (printf "%s-postgres" $.Release.Name) }}
+      key: {{ .auth.secretKeys.passwordKey | default "postgres-password" }}
   {{- end }}
   {{- else if .Values.mariadb.enabled }}
   {{- with .Values.mariadb}}
@@ -40,7 +40,7 @@ env:
     secretKeyRef:
       name: {{ .auth.existingSecret | default (printf "%s-redis" $.Release.Name) }}
       key: {{ .auth.existingSecretPasswordKey | default "redis-password" }}
-  PAPERLESS_REDIS: redis://{{ .auth.username }}:$(A_REDIS_PASSWORD)@{{ $.Release.Name }}-redis-master
+  PAPERLESS_REDIS: redis://{{ .auth.username }}:$(A_REDIS_PASSWORD)@{{ $.Release.Name }}-redis
   {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/paperless-ngx/values.yaml
+++ b/charts/paperless-ngx/values.yaml
@@ -70,8 +70,8 @@ persistence:
     retain: true
     mountPath: /usr/src/paperless/export
     # storageClass: ""
-    # accessMode: ReadWriteOnce
-    # size: 1Gi
+    accessMode: ReadWriteOnce
+    size: 1Gi
   # -- Configure consume volume settings for the chart under this key.
   # @default -- See [values.yaml](./values.yaml)
   consume:
@@ -79,27 +79,26 @@ persistence:
     retain: true
     mountPath: /usr/src/paperless/consume
     # storageClass: ""
-    # accessMode: ReadWriteOnce
-    # size: 4Gi
+    accessMode: ReadWriteOnce
+    size: 4Gi
 
 # -- Enable and configure postgresql database subchart under this key.
 #    If enabled, the app's db envs will be set for you.
-#    [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
+#    [[ref]](https://github.com/CloudPirates-io/helm-charts/tree/main/charts/postgres)
 # @default -- See [values.yaml](./values.yaml)
 postgresql:
   enabled: false
   auth:
-    database: paperless
-    postgresPassword: changeme
-  primary:
-    persistence:
-      enabled: false
-      # storageClass: ""
-      # size: 8Gi
+    username: paperless
+    password: changeme
+  persistence:
+    enabled: false
+    # storageClass: ""
+    # size: 8Gi
 
 # -- Enable and configure mariadb database subchart under this key.
 #    If enabled, the app's db envs will be set for you.
-#    [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/mariadb)
+#    [[ref]](https://github.com/CloudPirates-io/helm-charts/tree/main/charts/mariadb)
 # @default -- See [values.yaml](./values.yaml)
 mariadb:
   enabled: false
@@ -108,27 +107,22 @@ mariadb:
     username: paperless
     password: changeme
     rootPassword: changeme
-  primary:
-    persistence:
-      enabled: false
-      # storageClass: ""
-      # size: 8Gi
+  persistence:
+    enabled: false
+    # storageClass: ""
+    # size: 8Gi
 
 # -- Enable and configure redis subchart under this key.
 #    If enabled, the app's Redis env will be set for you.
-#    [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/redis)
+#    [[ref]](https://github.com/CloudPirates-io/helm-charts/tree/main/charts/redis)
 # @default -- See [values.yaml](./values.yaml)
 redis:
   enabled: true
   auth:
     enabled: true
-    username: ""
     # Use an existing secret for redis auth. Do this if you're using Argo to manage your instance or otherwise using helm template under the hood
     #     The secret name can vary, but the password key must be redis-password.
     # existingSecret: paperless-redis
     # existingSecretPasswordKey: redis-password
-  master:
-    persistence:
-      enabled: false
-  replica:
-    replicaCount: 0
+  persistence:
+    enabled: false


### PR DESCRIPTION
as you may know bitnami stopped providing image updates as they did in the past.

Attached commit is switching to a different helm-chart and official images instead of bitnami ones.

Sadly the new chart has a different values-syntax, so would be some breaking change.